### PR TITLE
Enhance types and forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,21 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Stock News AI
+
+Stock News AI is a simple Next.js application that displays stock market headlines stored in Supabase. It includes a small admin panel for managing news items and uses Supabase Auth for sign up and log in.
 
 ## Getting Started
 
-First, run the development server:
+1. Create a `.env.local` file and set `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`.
+2. Install dependencies with `npm install`.
+3. Run the development server with `npm run dev`.
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
+Open <http://localhost:3000> in your browser to see the app.
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Features
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+- User authentication via Supabase
+- Admin panel to add or delete headlines
+- Tailwind CSS styling
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## Deployment
 
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+This project can be deployed to any Node.js environment. For an easy deployment, consider using [Vercel](https://vercel.com/).

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,11 +2,12 @@
 
 import { useEffect, useState } from 'react'
 import { supabase } from '@/lib/supabase'
+import type { NewsItem, NewsFormData } from '@lib/types'
 
 export default function AdminPage() {
-  const [newsItems, setNewsItems] = useState<any[]>([])
+  const [newsItems, setNewsItems] = useState<NewsItem[]>([])
   const [loading, setLoading] = useState(true)
-  const [form, setForm] = useState({
+  const [form, setForm] = useState<NewsFormData>({
     headline: '',
     ticker: '',
     sentiment: '',
@@ -27,7 +28,7 @@ export default function AdminPage() {
     if (error) {
       console.error('Failed to load news:', error)
     } else {
-      setNewsItems(data || [])
+      setNewsItems((data || []) as NewsItem[])
     }
 
     setLoading(false)

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -34,9 +34,12 @@ export default function LoginPage() {
         <h1 className="text-2xl font-bold mb-4 text-center">Log In</h1>
 
         <form onSubmit={handleLogin} className="space-y-4">
+          <label className="block text-sm" htmlFor="email">Email</label>
           <input
+            id="email"
             type="email"
             placeholder="Email"
+            autoComplete="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required
@@ -44,9 +47,12 @@ export default function LoginPage() {
           />
 
           <div className="relative">
+            <label className="block text-sm" htmlFor="password">Password</label>
             <input
+              id="password"
               type={showPassword ? 'text' : 'password'}
               placeholder="Password"
+              autoComplete="current-password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,9 +3,10 @@
 import { useEffect, useState } from 'react';
 import { createPagesBrowserClient } from '@supabase/auth-helpers-nextjs';
 import { useRouter } from 'next/navigation';
+import type { NewsItem } from '@lib/types';
 
 export default function Home() {
-  const [newsItems, setNewsItems] = useState<any[]>([]);
+  const [newsItems, setNewsItems] = useState<NewsItem[]>([]);
   const [loading, setLoading] = useState(true);
   const router = useRouter();
 
@@ -33,7 +34,7 @@ export default function Home() {
       if (error) {
         console.error('Failed to fetch news items:', error);
       } else {
-        setNewsItems(data);
+        setNewsItems((data || []) as NewsItem[]);
       }
 
       setLoading(false);

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -40,9 +40,12 @@ export default function SignupPage() {
         <h1 className="text-2xl font-bold mb-4 text-center">Create Account</h1>
 
         <form onSubmit={handleSignup} className="space-y-4">
+          <label className="block text-sm" htmlFor="email">Email</label>
           <input
+            id="email"
             type="email"
             placeholder="Email"
+            autoComplete="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required
@@ -50,9 +53,12 @@ export default function SignupPage() {
           />
 
           <div className="relative">
+            <label className="block text-sm" htmlFor="password">Password</label>
             <input
+              id="password"
               type={showPassword ? 'text' : 'password'}
               placeholder="Password"
+              autoComplete="new-password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,15 @@
+export interface NewsItem {
+  id: string;
+  headline: string;
+  ticker: string;
+  sentiment: string;
+  signal: string;
+  published_at: string;
+}
+
+export interface NewsFormData {
+  headline: string;
+  ticker: string;
+  sentiment: string;
+  signal: string;
+}


### PR DESCRIPTION
## Summary
- define `NewsItem` and `NewsFormData` types
- use these types in pages
- add labels and autocomplete to auth forms
- document environment vars in README

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bf797354c832daf2caa9cb240d920